### PR TITLE
Permitindo blocos nulos

### DIFF
--- a/lang/nodes/LangVisitor.java
+++ b/lang/nodes/LangVisitor.java
@@ -16,6 +16,7 @@ public abstract class LangVisitor{
     public abstract void visit(CSeq d);
     public abstract void visit(CAttr d);
     public abstract void visit(CDecl d);
+    public abstract void visit(CNull d);
     public abstract void visit(Loop d);
     public abstract void visit(IterateWithVar d);
     public abstract void visit(If d);

--- a/lang/nodes/command/CNull.java
+++ b/lang/nodes/command/CNull.java
@@ -1,0 +1,16 @@
+package lang.nodes.command;
+
+import lang.nodes.CNode;
+import lang.nodes.LangVisitor;
+
+public class CNull extends CNode {
+
+    public CNull(int line, int col) {
+        super(line, col);
+    }
+
+    @Override
+    public void accept(LangVisitor v) {
+        v.visit(this);
+    }
+}

--- a/lang/nodes/visitors/GVizVisitor.java
+++ b/lang/nodes/visitors/GVizVisitor.java
@@ -79,6 +79,11 @@ public  class GVizVisitor extends LangVisitor{
                subNode=  root;
      }
 
+     public void visit(CNull d){
+               int root = gf.addNode("Null");
+               gf.addEdge(root,subNode);
+     }
+
      public void visit(Loop d){
                int root = gf.addNode("Loop");
                d.getCond().accept(this);

--- a/lang/nodes/visitors/InterpVisitor.java
+++ b/lang/nodes/visitors/InterpVisitor.java
@@ -116,6 +116,8 @@ public class InterpVisitor extends LangVisitor {
         }
     }
 
+    public void visit(CNull d) {}
+
     public void visit(Loop d) {
         if (!retMode) {
             d.getCond().accept(this);

--- a/lang/nodes/visitors/SimpleVisitor.java
+++ b/lang/nodes/visitors/SimpleVisitor.java
@@ -19,6 +19,7 @@ public class SimpleVisitor extends LangVisitor{
     public void visit(CSeq d) { }
     public void visit(CAttr d) { }
     public void visit(CDecl d) { }
+    public void visit(CNull d) { }
     public void visit(Loop d) { }
     public void visit(IterateWithVar d) { }
     public void visit(If d) { }

--- a/lang/nodes/visitors/tychkvisitor/TyChecker.java
+++ b/lang/nodes/visitors/tychkvisitor/TyChecker.java
@@ -169,6 +169,10 @@ public class TyChecker extends LangVisitor {
         
         declareVar(d.getVar().getName(), varType, d.getLine(), d.getCol());
     }
+
+    public void visit(CNull d) {
+        // vazio
+    }
     
 
     public void visit(Loop d) {

--- a/lang/parser/lang.cup
+++ b/lang/parser/lang.cup
@@ -97,7 +97,6 @@ cmdList ::= cmd:c                         {: RESULT = c; :}
        |    cmdList:cl cmd:c              {: RESULT = new CSeq(clleft, clright, cl, c); :}
        ;
 
-/*   public Loop(int l, int c, Exp e, CNode body){*/
 cmd ::= block:b                                                       {: RESULT = b; :}   
        | ID:id ASSIGN expr:e SEMICOLON                                {: RESULT = new CAttr(idleft, idright, new Var(idleft, idright, id), e); :}
        | btype:t ID:id ASSIGN expr:e SEMICOLON                        {: RESULT = new CDecl(tleft, tright, t, new Var(idleft, idright, id), e); :}
@@ -115,6 +114,7 @@ btype ::= INT_TYPE:t                        {: RESULT = new TyInt(tleft, tright)
        ;
 
 block ::= OPEN_BRACE cmdList:e CLOSE_BRACE  {: RESULT = e; :}
+       | OPEN_BRACE  CLOSE_BRACE            {: RESULT = new CNull(0, 0); :}
        ;
 
 expr ::= expr:e1 AND:t expr:e2            {: RESULT = new And(tleft,tright,e1,e2);         :}

--- a/testes/teste2.lang
+++ b/testes/teste2.lang
@@ -1,5 +1,5 @@
 Int val = 1000;
 
-if (val < 500) {
-    print true;
+iterate (val) {
+    
 }


### PR DESCRIPTION
Como previsto pela definição da gramática, blocos vazios são permitidos. A alteração visa adicionar essa funcionalidade